### PR TITLE
Fix for Zone toggle/on/off issue

### DIFF
--- a/custom_components/advantage_air_test/climate.py
+++ b/custom_components/advantage_air_test/climate.py
@@ -295,7 +295,7 @@ class AdvantageAirZone(AdvantageAirZoneEntity, ClimateEntity):
                     "zones": {
                         self.zone_key: {
                             "state": ADVANTAGE_AIR_STATE_OPEN
-                            if hvac_mode == HVACMode.OFF
+                            if hvac_mode != HVACMode.OFF
                             else ADVANTAGE_AIR_STATE_CLOSE
                         }
                     }


### PR DESCRIPTION
Fixes #1

Reverses logic for Zone async_set_hvac_mode so that turn_on and turn_off work as expected, along with the correct set_hvac_mode response.

Tested with MyAir5 system.