### PR TITLE
deprecation of hass.config_entries.async_setup_platforms

### DIFF
--- a/custom_components/advantage_air_test/__init__.py
+++ b/custom_components/advantage_air_test/__init__.py
@@ -7,6 +7,7 @@ from .advantage_air import ApiError, advantage_air
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -59,7 +60,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 if await func(param):
                     await coordinator.async_refresh()
             except ApiError as err:
-                _LOGGER.warning(err)
+                raise HomeAssistantError(err) from err
 
         return error_handle
 
@@ -73,7 +74,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         "things": error_handle_factory(api.things.async_set),
     }
 
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 

--- a/custom_components/advantage_air_test/config_flow.py
+++ b/custom_components/advantage_air_test/config_flow.py
@@ -1,9 +1,14 @@
 """Config Flow for Advantage Air integration."""
+from __future__ import annotations
+
+from typing import Any
+
 from .advantage_air import ApiError, advantage_air
 import voluptuous as vol
 
 from homeassistant import config_entries
 from homeassistant.const import CONF_IP_ADDRESS, CONF_PORT
+from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
 from .const import ADVANTAGE_AIR_RETRY, DOMAIN
@@ -25,7 +30,9 @@ class AdvantageAirConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     DOMAIN = DOMAIN
 
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Get configuration from the user."""
         errors = {}
         if user_input:


### PR DESCRIPTION
These are your changes from the GA `advantage_air` component.

`hass.config_entries.async_setup_platforms` is deprecated and will be removed in `2023.3`.